### PR TITLE
refactor(cmd): remove duplicated code for making spec

### DIFF
--- a/cmd/resource/builder.go
+++ b/cmd/resource/builder.go
@@ -1,0 +1,83 @@
+package resource
+
+import (
+	"io"
+	"io/fs"
+
+	"github.com/siyul-park/uniflow/pkg/scheme"
+)
+
+type (
+	Builder struct {
+		scheme    *scheme.Scheme
+		namespace string
+		fsys      fs.FS
+		filename  string
+	}
+)
+
+func NewBuilder() *Builder {
+	return &Builder{}
+}
+
+func (b *Builder) Scheme(scheme *scheme.Scheme) *Builder {
+	b.scheme = scheme
+	return b
+}
+
+func (b *Builder) Namespace(namespace string) *Builder {
+	b.namespace = namespace
+	return b
+}
+
+func (b *Builder) FS(fsys fs.FS) *Builder {
+	b.fsys = fsys
+	return b
+}
+
+func (b *Builder) Filename(filename string) *Builder {
+	b.filename = filename
+	return b
+}
+
+func (b *Builder) Build() ([]scheme.Spec, error) {
+	if b.fsys == nil || b.filename == "" {
+		return nil, nil
+	}
+	file, err := b.fsys.Open(b.filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+
+	var raws []map[string]any
+	if err := UnmarshalYAMLOrJSON(data, &raws); err != nil {
+		var e map[string]any
+		if err := UnmarshalYAMLOrJSON(data, &e); err != nil {
+			return nil, err
+		} else {
+			raws = []map[string]any{e}
+		}
+	}
+
+	codec := NewSpecCodec(SpecCodecOptions{
+		Scheme:    b.scheme,
+		Namespace: b.namespace,
+	})
+
+	var specs []scheme.Spec
+	for _, raw := range raws {
+		if spec, err := codec.Decode(raw); err != nil {
+			return nil, err
+		} else {
+			specs = append(specs, spec)
+		}
+	}
+
+	return specs, nil
+}

--- a/cmd/resource/builder_test.go
+++ b/cmd/resource/builder_test.go
@@ -1,0 +1,50 @@
+package resource
+
+import (
+	"encoding/json"
+	"testing"
+	"testing/fstest"
+
+	"github.com/go-faker/faker/v4"
+	"github.com/oklog/ulid/v2"
+	"github.com/siyul-park/uniflow/pkg/node"
+	"github.com/siyul-park/uniflow/pkg/scheme"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuilder_Build(t *testing.T) {
+	s := scheme.New()
+	fsys := make(fstest.MapFS)
+
+	filename := "spec.json"
+	kind := faker.Word()
+
+	spec := &scheme.SpecMeta{
+		ID:        ulid.Make(),
+		Kind:      kind,
+		Namespace: scheme.NamespaceDefault,
+	}
+
+	codec := scheme.CodecFunc(func(spec scheme.Spec) (node.Node, error) {
+		return node.NewOneToOneNode(node.OneToOneNodeConfig{ID: spec.GetID()}), nil
+	})
+
+	s.AddKnownType(kind, &scheme.SpecMeta{})
+	s.AddCodec(kind, codec)
+
+	data, _ := json.Marshal(spec)
+
+	fsys[filename] = &fstest.MapFile{
+		Data: data,
+	}
+
+	builder := NewBuilder().
+		Scheme(s).
+		Namespace(scheme.NamespaceDefault).
+		FS(fsys).
+		Filename(filename)
+
+	specs, err := builder.Build()
+	assert.NoError(t, err)
+	assert.Len(t, specs, 1)
+}

--- a/cmd/uniflow/start/cmd.go
+++ b/cmd/uniflow/start/cmd.go
@@ -1,7 +1,6 @@
 package start
 
 import (
-	"io"
 	"io/fs"
 	"os"
 	"os/signal"
@@ -67,39 +66,15 @@ func NewCmd(config Config) *cobra.Command {
 				}); err != nil {
 					return err
 				} else if len(specs) == 0 {
-					file, err := fsys.Open(boot)
+					b := resource.NewBuilder().
+						Scheme(sc).
+						Namespace(ns).
+						FS(fsys).
+						Filename(boot)
+
+					specs, err := b.Build()
 					if err != nil {
 						return err
-					}
-					defer func() { _ = file.Close() }()
-
-					data, err := io.ReadAll(file)
-					if err != nil {
-						return err
-					}
-
-					var raws []map[string]any
-					if err := resource.UnmarshalYAMLOrJSON(data, &raws); err != nil {
-						var e map[string]any
-						if err := resource.UnmarshalYAMLOrJSON(data, &e); err != nil {
-							return err
-						} else {
-							raws = []map[string]any{e}
-						}
-					}
-
-					codec := resource.NewSpecCodec(resource.SpecCodecOptions{
-						Scheme:    sc,
-						Namespace: ns,
-					})
-
-					var specs []scheme.Spec
-					for _, raw := range raws {
-						if spec, err := codec.Decode(raw); err != nil {
-							return err
-						} else {
-							specs = append(specs, spec)
-						}
 					}
 
 					if _, err := st.InsertMany(ctx, specs); err != nil {

--- a/pkg/scheme/unstructured.go
+++ b/pkg/scheme/unstructured.go
@@ -9,7 +9,6 @@ import (
 )
 
 type (
-
 	// Unstructured is an Spec that is not marshaled for structuring.
 	Unstructured struct {
 		doc *primitive.Map

--- a/pkg/scheme/unstructured.go
+++ b/pkg/scheme/unstructured.go
@@ -73,7 +73,6 @@ func (u *Unstructured) GetNamespace() string {
 	var val string
 	_ = u.Get(KeyNamespace, &val)
 	return val
-
 }
 
 // SetNamespace sets the Namespace of the Unstructured.


### PR DESCRIPTION
## Changes Made

- Eliminated duplicated code related to spec creation.
- Introduced a Builder pattern for assembling specs from various sources.

## Details

In this update, redundant code for constructing specs has been removed, enhancing code maintainability and reducing redundancy.

The addition of a Builder pattern allows the creation of specs from multiple sources in a more modular and organized manner. This not only improves code readability but also provides flexibility for future expansions.

These changes aim to streamline the codebase and promote a more structured approach to spec creation.