### PR TITLE
feat: support in/out port in http

### DIFF
--- a/examples/echo.yaml
+++ b/examples/echo.yaml
@@ -2,7 +2,7 @@
   name: http
   address: :8000
   links:
-    io:
+    out:
       - name: router
         port: in
 
@@ -15,4 +15,4 @@
   links:
     out[0]:
       - name: http
-        port: io
+        port: in


### PR DESCRIPTION
## Changes Made

- Added `in` and `out` ports to the `http` node.
- Revised the echo example to utilize the `in` and `out` ports for a more controlled packet processing flow.
- Limited that the `out`/`io` ports were the packet processing to backward direction.

## Details

This update enhances the functionality of the HTTP node by introducing `in` and `out` ports. The revised echo example now takes advantage of these ports, providing a more flexible and controlled packet processing flow.

These changes aim to improve the overall versatility and usability of the system.
