### PR TITLE
feat: add error when calling `process.Exit`

### DIFF
--- a/pkg/hook/hook.go
+++ b/pkg/hook/hook.go
@@ -14,8 +14,8 @@ type Hook struct {
 	mu          sync.RWMutex
 }
 
-var _ symbol.LoadHook = &Hook{}
-var _ symbol.UnloadHook = &Hook{}
+var _ symbol.LoadHook = (*Hook)(nil)
+var _ symbol.UnloadHook = (*Hook)(nil)
 
 // New creates a new Hook instance.
 func New() *Hook {

--- a/pkg/node/onetomany.go
+++ b/pkg/node/onetomany.go
@@ -27,7 +27,7 @@ type (
 	}
 )
 
-var _ Node = &OneToManyNode{}
+var _ Node = (*OneToManyNode)(nil)
 
 // NewOneToManyNode returns a new OneToManyNode.
 func NewOneToManyNode(config OneToManyNodeConfig) *OneToManyNode {

--- a/pkg/node/onetomany_test.go
+++ b/pkg/node/onetomany_test.go
@@ -64,7 +64,7 @@ func TestOneToManyNode_Send(t *testing.T) {
 		outPort.Link(out)
 
 		proc := process.New()
-		defer proc.Exit()
+		defer proc.Exit(nil)
 
 		inStream := in.Open(proc)
 		outStream := out.Open(proc)
@@ -109,7 +109,7 @@ func TestOneToManyNode_Send(t *testing.T) {
 		errPort.Link(err)
 
 		proc := process.New()
-		defer proc.Exit()
+		defer proc.Exit(nil)
 
 		inStream := in.Open(proc)
 		errStream := err.Open(proc)

--- a/pkg/node/onetoone.go
+++ b/pkg/node/onetoone.go
@@ -28,7 +28,7 @@ type (
 	}
 )
 
-var _ Node = &OneToOneNode{}
+var _ Node = (*OneToOneNode)(nil)
 
 // NewOneToOneNode returns a new OneToOneNode.
 func NewOneToOneNode(config OneToOneNodeConfig) *OneToOneNode {

--- a/pkg/node/onetoone_test.go
+++ b/pkg/node/onetoone_test.go
@@ -65,7 +65,7 @@ func TestOneToOneNode_Send(t *testing.T) {
 			ioPort.Link(io)
 
 			proc := process.New()
-			defer proc.Exit()
+			defer proc.Exit(nil)
 
 			ioStream := io.Open(proc)
 
@@ -102,7 +102,7 @@ func TestOneToOneNode_Send(t *testing.T) {
 			errPort.Link(err)
 
 			proc := process.New()
-			defer proc.Exit()
+			defer proc.Exit(nil)
 
 			ioStream := io.Open(proc)
 			errStream := err.Open(proc)
@@ -142,7 +142,7 @@ func TestOneToOneNode_Send(t *testing.T) {
 			outPort.Link(out)
 
 			proc := process.New()
-			defer proc.Exit()
+			defer proc.Exit(nil)
 
 			inStream := in.Open(proc)
 			outStream := out.Open(proc)
@@ -188,7 +188,7 @@ func TestOneToOneNode_Send(t *testing.T) {
 			errPort.Link(err)
 
 			proc := process.New()
-			defer proc.Exit()
+			defer proc.Exit(nil)
 
 			inStream := in.Open(proc)
 			errStream := err.Open(proc)

--- a/pkg/packet/error.go
+++ b/pkg/packet/error.go
@@ -1,10 +1,15 @@
 package packet
 
-import "github.com/siyul-park/uniflow/pkg/primitive"
+import (
+	"errors"
 
-// NewError creates a new Packet to represent an error.
-// It takes an error and an optional cause Packet and constructs a Packet with error details.
-func NewError(err error, cause *Packet) *Packet {
+	"github.com/siyul-park/uniflow/pkg/primitive"
+)
+
+// WithError creates a new Packet representing an error with the given error and optional cause.
+// It constructs a Packet with error details, including the error message.
+// If a cause is provided, it is attached to the error packet.
+func WithError(err error, cause *Packet) *Packet {
 	pairs := []primitive.Value{
 		primitive.NewString("error"),
 		primitive.NewString(err.Error()),
@@ -17,9 +22,14 @@ func NewError(err error, cause *Packet) *Packet {
 	return New(primitive.NewMap(pairs...))
 }
 
-// IsError checks if the given Packet represents an error.
-func IsError(pck *Packet) bool {
+// AsError extracts the error from a Packet, returning it along with a boolean indicating whether
+// the Packet contains error information. If the Packet does not represent an error, the
+// returned error is nil, and the boolean is false.
+func AsError(pck *Packet) (error, bool) {
 	payload := pck.Payload()
-	_, ok := primitive.Pick[string](payload, "error")
-	return ok
+	err, ok := primitive.Pick[string](payload, "error")
+	if !ok {
+		return nil, false
+	}
+	return errors.New(err), true
 }

--- a/pkg/packet/error.go
+++ b/pkg/packet/error.go
@@ -1,0 +1,25 @@
+package packet
+
+import "github.com/siyul-park/uniflow/pkg/primitive"
+
+// NewError creates a new Packet to represent an error.
+// It takes an error and an optional cause Packet and constructs a Packet with error details.
+func NewError(err error, cause *Packet) *Packet {
+	pairs := []primitive.Value{
+		primitive.NewString("error"),
+		primitive.NewString(err.Error()),
+	}
+
+	if cause != nil {
+		pairs = append(pairs, primitive.NewString("cause"), cause.Payload())
+	}
+
+	return New(primitive.NewMap(pairs...))
+}
+
+// IsError checks if the given Packet represents an error.
+func IsError(pck *Packet) bool {
+	payload := pck.Payload()
+	_, ok := primitive.Pick[string](payload, "error")
+	return ok
+}

--- a/pkg/packet/error_test.go
+++ b/pkg/packet/error_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewError(t *testing.T) {
+func TestWithError(t *testing.T) {
 	err := errors.New(faker.Sentence())
 
 	pck1 := New(primitive.NewString(faker.Word()))
-	pck2 := NewError(err, pck1)
+	pck2 := WithError(err, pck1)
 
 	assert.NotNil(t, pck2)
 	assert.NotZero(t, pck2.ID())
@@ -24,12 +24,13 @@ func TestNewError(t *testing.T) {
 	assert.Equal(t, pck1.Payload(), payload.GetOr(primitive.NewString("cause"), nil))
 }
 
-func TestIsError(t *testing.T) {
+func TestAsError(t *testing.T) {
 	err := errors.New(faker.Sentence())
 
 	pck1 := New(primitive.NewString(faker.Word()))
-	pck2 := NewError(err, pck1)
+	pck2 := WithError(err, pck1)
 
-	assert.True(t, IsError(pck2))
-	assert.False(t, IsError(pck1))
+	err1, ok := AsError(pck2)
+	assert.True(t, ok)
+	assert.Equal(t, err.Error(), err1.Error())
 }

--- a/pkg/packet/error_test.go
+++ b/pkg/packet/error_test.go
@@ -1,0 +1,35 @@
+package packet
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/go-faker/faker/v4"
+	"github.com/siyul-park/uniflow/pkg/primitive"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewError(t *testing.T) {
+	err := errors.New(faker.Sentence())
+
+	pck1 := New(primitive.NewString(faker.Word()))
+	pck2 := NewError(err, pck1)
+
+	assert.NotNil(t, pck2)
+	assert.NotZero(t, pck2.ID())
+
+	payload, ok := pck2.Payload().(*primitive.Map)
+	assert.True(t, ok)
+	assert.Equal(t, err.Error(), payload.GetOr(primitive.NewString("error"), nil).Interface())
+	assert.Equal(t, pck1.Payload(), payload.GetOr(primitive.NewString("cause"), nil))
+}
+
+func TestIsError(t *testing.T) {
+	err := errors.New(faker.Sentence())
+
+	pck1 := New(primitive.NewString(faker.Word()))
+	pck2 := NewError(err, pck1)
+
+	assert.True(t, IsError(pck2))
+	assert.False(t, IsError(pck1))
+}

--- a/pkg/packet/packet.go
+++ b/pkg/packet/packet.go
@@ -11,21 +11,6 @@ type Packet struct {
 	payload primitive.Value
 }
 
-// NewError creates a new Packet to represent an error.
-// It takes an error and an optional cause Packet and constructs a Packet with error details.
-func NewError(err error, cause *Packet) *Packet {
-	pairs := []primitive.Value{
-		primitive.NewString("error"),
-		primitive.NewString(err.Error()),
-	}
-
-	if cause != nil {
-		pairs = append(pairs, primitive.NewString("cause"), cause.Payload())
-	}
-
-	return New(primitive.NewMap(pairs...))
-}
-
 // New creates a new Packet with the given payload.
 // It generates a new unique ID for the Packet.
 func New(payload primitive.Value) *Packet {

--- a/pkg/packet/packet_test.go
+++ b/pkg/packet/packet_test.go
@@ -1,28 +1,10 @@
 package packet
 
 import (
-	"errors"
 	"testing"
 
-	"github.com/go-faker/faker/v4"
-	"github.com/siyul-park/uniflow/pkg/primitive"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestNewError(t *testing.T) {
-	err := errors.New(faker.Sentence())
-
-	pck1 := New(primitive.NewString(faker.Word()))
-	pck2 := NewError(err, pck1)
-
-	assert.NotNil(t, pck2)
-	assert.NotZero(t, pck2.ID())
-
-	payload, ok := pck2.Payload().(*primitive.Map)
-	assert.True(t, ok)
-	assert.Equal(t, err.Error(), payload.GetOr(primitive.NewString("error"), nil).Interface())
-	assert.Equal(t, pck1.Payload(), payload.GetOr(primitive.NewString("cause"), nil))
-}
 
 func TestNew(t *testing.T) {
 	pck := New(nil)

--- a/pkg/plugin/controllx/snippet.go
+++ b/pkg/plugin/controllx/snippet.go
@@ -92,9 +92,9 @@ func (n *SnippetNode) action(proc *process.Process, inPck *packet.Packet) (*pack
 	}
 
 	if output, err := n.run(input); err != nil {
-		return nil, packet.NewError(err, inPck)
+		return nil, packet.WithError(err, inPck)
 	} else if outPayload, err := primitive.MarshalText(output); err != nil {
-		return nil, packet.NewError(err, inPck)
+		return nil, packet.WithError(err, inPck)
 	} else {
 		return packet.New(outPayload), nil
 	}

--- a/pkg/plugin/controllx/snippet_test.go
+++ b/pkg/plugin/controllx/snippet_test.go
@@ -44,7 +44,7 @@ function main(inPayload: any): any {
 		ioPort.Link(io)
 
 		proc := process.New()
-		defer proc.Exit()
+		defer proc.Exit(nil)
 
 		ioStream := io.Open(proc)
 
@@ -80,7 +80,7 @@ function main(inPayload) {
 		ioPort.Link(io)
 
 		proc := process.New()
-		defer proc.Exit()
+		defer proc.Exit(nil)
 
 		ioStream := io.Open(proc)
 
@@ -114,7 +114,7 @@ function main(inPayload) {
 		ioPort.Link(io)
 
 		proc := process.New()
-		defer proc.Exit()
+		defer proc.Exit(nil)
 
 		ioStream := io.Open(proc)
 
@@ -146,7 +146,7 @@ function main(inPayload) {
 		ioPort.Link(io)
 
 		proc := process.New()
-		defer proc.Exit()
+		defer proc.Exit(nil)
 
 		ioStream := io.Open(proc)
 
@@ -185,7 +185,7 @@ function main(inPayload: any): any {
 
 		for i := 0; i < b.N; i++ {
 			proc := process.New()
-			defer proc.Exit()
+			defer proc.Exit(nil)
 
 			ioStream := io.Open(proc)
 
@@ -222,7 +222,7 @@ function main(inPayload) {
 
 		for i := 0; i < b.N; i++ {
 			proc := process.New()
-			defer proc.Exit()
+			defer proc.Exit(nil)
 
 			ioStream := io.Open(proc)
 
@@ -255,7 +255,7 @@ function main(inPayload) {
 
 		for i := 0; i < b.N; i++ {
 			proc := process.New()
-			defer proc.Exit()
+			defer proc.Exit(nil)
 
 			ioStream := io.Open(proc)
 
@@ -288,7 +288,7 @@ function main(inPayload) {
 
 		for i := 0; i < b.N; i++ {
 			proc := process.New()
-			defer proc.Exit()
+			defer proc.Exit(nil)
 
 			ioStream := io.Open(proc)
 

--- a/pkg/plugin/controllx/switch.go
+++ b/pkg/plugin/controllx/switch.go
@@ -106,5 +106,5 @@ func (n *SwitchNode) action(proc *process.Process, inPck *packet.Packet) ([]*pac
 		}
 	}
 
-	return nil, packet.NewError(node.ErrDiscardPacket, inPck)
+	return nil, packet.WithError(node.ErrDiscardPacket, inPck)
 }

--- a/pkg/plugin/controllx/switch_test.go
+++ b/pkg/plugin/controllx/switch_test.go
@@ -79,7 +79,7 @@ func TestSwitchNode_Send(t *testing.T) {
 			outPort.Link(out)
 
 			proc := process.New()
-			defer proc.Exit()
+			defer proc.Exit(nil)
 
 			inStream := in.Open(proc)
 			outStream := out.Open(proc)

--- a/pkg/plugin/networkx/http.go
+++ b/pkg/plugin/networkx/http.go
@@ -379,8 +379,9 @@ func (n *HTTPNode) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	n.mu.RLock()
 	defer n.mu.RUnlock()
 
-	proc := process.New()
 	var procErr error
+	proc := process.New()
+
 	defer func() {
 		proc.Stack().Wait()
 		proc.Exit(procErr)
@@ -404,12 +405,14 @@ func (n *HTTPNode) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		_ = n.response(r, w, n.errorPayload(proc, UnsupportedMediaType))
 		return
 	}
+
 	outPayload, err := primitive.MarshalText(req)
 	if err != nil {
 		procErr = err
 		_ = n.response(r, w, n.errorPayload(proc, BadRequest))
 		return
 	}
+
 	outPck := packet.New(outPayload)
 
 	if ioStream.Links() > 0 {

--- a/pkg/plugin/networkx/http.go
+++ b/pkg/plugin/networkx/http.go
@@ -199,7 +199,7 @@ var (
 )
 
 var _ node.Node = (*HTTPNode)(nil)
-var _ http.Handler = &HTTPNode{}
+var _ http.Handler = (*HTTPNode)(nil)
 var _ scheme.Spec = (*HTTPSpec)(nil)
 
 var forbiddenResponseHeaderRegexps []*regexp.Regexp

--- a/pkg/plugin/networkx/http.go
+++ b/pkg/plugin/networkx/http.go
@@ -382,13 +382,13 @@ func (n *HTTPNode) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	proc := process.New()
 	defer func() {
 		proc.Stack().Wait()
-		proc.Exit()
+		proc.Exit(nil)
 	}()
 
 	go func() {
 		select {
 		case <-r.Context().Done():
-			proc.Exit()
+			proc.Exit(r.Context().Err())
 		case <-proc.Done():
 		}
 	}()
@@ -451,7 +451,7 @@ func (n *HTTPNode) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		var res HTTPPayload
 		if err := primitive.Unmarshal(inPayload, &res); err != nil {
-			if packet.IsError(inPck) {
+			if _, ok := packet.AsError(inPck); ok {
 				res = InternalServerError
 			} else {
 				res.Body = inPayload

--- a/pkg/plugin/networkx/http.go
+++ b/pkg/plugin/networkx/http.go
@@ -417,6 +417,7 @@ func (n *HTTPNode) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		proc.Stack().Push(outPck.ID(), outStream.ID())
 		outStream.Send(outPck)
 	}
+
 	if ioStream.Links()+outStream.Links() == 0 {
 		return
 	}
@@ -450,7 +451,11 @@ func (n *HTTPNode) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		var res HTTPPayload
 		if err := primitive.Unmarshal(inPayload, &res); err != nil {
-			res.Body = inPayload
+			if packet.IsError(inPck) {
+				res = InternalServerError
+			} else {
+				res.Body = inPayload
+			}
 		}
 
 		if err := n.response(r, w, res); err != nil {

--- a/pkg/plugin/networkx/router.go
+++ b/pkg/plugin/networkx/router.go
@@ -151,15 +151,15 @@ func (n *RouterNode) action(proc *process.Process, inPck *packet.Packet) ([]*pac
 
 	inPayload, ok := inPck.Payload().(*primitive.Map)
 	if !ok {
-		return nil, packet.NewError(node.ErrInvalidPacket, inPck)
+		return nil, packet.WithError(node.ErrInvalidPacket, inPck)
 	}
 	method, ok := primitive.Pick[string](inPayload, KeyMethod)
 	if !ok {
-		return nil, packet.NewError(node.ErrInvalidPacket, inPck)
+		return nil, packet.WithError(node.ErrInvalidPacket, inPck)
 	}
 	path, ok := primitive.Pick[string](inPayload, KeyPath)
 	if !ok {
-		return nil, packet.NewError(node.ErrInvalidPacket, inPck)
+		return nil, packet.WithError(node.ErrInvalidPacket, inPck)
 	}
 
 	pre, cur, values := n.find(method, path)

--- a/pkg/plugin/networkx/router_test.go
+++ b/pkg/plugin/networkx/router_test.go
@@ -71,7 +71,7 @@ func TestRouterNode_Send(t *testing.T) {
 			outPort.Link(out)
 
 			proc := process.New()
-			defer proc.Exit()
+			defer proc.Exit(nil)
 
 			inStream := in.Open(proc)
 			outStream := out.Open(proc)

--- a/pkg/plugin/systemx/reflect.go
+++ b/pkg/plugin/systemx/reflect.go
@@ -92,12 +92,12 @@ func (n *ReflectNode) action(proc *process.Process, inPck *packet.Packet) (*pack
 	case OPDelete:
 		filter, err := examplesToFilter(examples)
 		if err != nil {
-			return nil, packet.NewError(err, inPck)
+			return nil, packet.WithError(err, inPck)
 		}
 
 		specs, err := n.storage.FindMany(ctx, filter)
 		if err != nil {
-			return nil, packet.NewError(err, inPck)
+			return nil, packet.WithError(err, inPck)
 		}
 
 		var ids []ulid.ULID
@@ -106,14 +106,14 @@ func (n *ReflectNode) action(proc *process.Process, inPck *packet.Packet) (*pack
 		}
 
 		if _, err := n.storage.DeleteMany(ctx, storage.Where[ulid.ULID](scheme.KeyID).IN(ids...)); err != nil {
-			return nil, packet.NewError(err, inPck)
+			return nil, packet.WithError(err, inPck)
 		}
 
 		if len(specs) == 0 {
 			return nil, inPck
 		}
 		if outPayload, err := specsToExamples(specs, batch); err != nil {
-			return nil, packet.NewError(err, inPck)
+			return nil, packet.WithError(err, inPck)
 		} else {
 			return packet.New(outPayload), nil
 		}
@@ -122,40 +122,40 @@ func (n *ReflectNode) action(proc *process.Process, inPck *packet.Packet) (*pack
 
 		ids, err := n.storage.InsertMany(ctx, specs)
 		if err != nil {
-			return nil, packet.NewError(err, inPck)
+			return nil, packet.WithError(err, inPck)
 		}
 
 		specs, err = n.storage.FindMany(ctx, storage.Where[ulid.ULID](scheme.KeyID).IN(ids...), &database.FindOptions{
 			Limit: lo.ToPtr(len(ids)),
 		})
 		if err != nil {
-			return nil, packet.NewError(err, inPck)
+			return nil, packet.WithError(err, inPck)
 		}
 
 		if len(specs) == 0 {
 			return nil, inPck
 		}
 		if outPayload, err := specsToExamples(specs, batch); err != nil {
-			return nil, packet.NewError(err, inPck)
+			return nil, packet.WithError(err, inPck)
 		} else {
 			return packet.New(outPayload), nil
 		}
 	case OPSelect:
 		filter, err := examplesToFilter(examples)
 		if err != nil {
-			return nil, packet.NewError(err, inPck)
+			return nil, packet.WithError(err, inPck)
 		}
 
 		specs, err := n.storage.FindMany(ctx, filter)
 		if err != nil {
-			return nil, packet.NewError(err, inPck)
+			return nil, packet.WithError(err, inPck)
 		}
 
 		if len(specs) == 0 {
 			return nil, inPck
 		}
 		if outPayload, err := specsToExamples(specs, batch); err != nil {
-			return nil, packet.NewError(err, inPck)
+			return nil, packet.WithError(err, inPck)
 		} else {
 			return packet.New(outPayload), nil
 		}
@@ -177,14 +177,14 @@ func (n *ReflectNode) action(proc *process.Process, inPck *packet.Packet) (*pack
 			Limit: lo.ToPtr(len(ids)),
 		})
 		if err != nil {
-			return nil, packet.NewError(err, inPck)
+			return nil, packet.WithError(err, inPck)
 		}
 
 		var merges []scheme.Spec
 		for _, spec := range specs {
 			unstructured := scheme.NewUnstructured(nil)
 			if err := unstructured.Marshal(spec); err != nil {
-				return nil, packet.NewError(err, inPck)
+				return nil, packet.WithError(err, inPck)
 			}
 
 			patch := patches[spec.GetID()]
@@ -198,21 +198,21 @@ func (n *ReflectNode) action(proc *process.Process, inPck *packet.Packet) (*pack
 		}
 
 		if _, err := n.storage.UpdateMany(ctx, merges); err != nil {
-			return nil, packet.NewError(err, inPck)
+			return nil, packet.WithError(err, inPck)
 		}
 
 		specs, err = n.storage.FindMany(ctx, storage.Where[ulid.ULID](scheme.KeyID).IN(ids...), &database.FindOptions{
 			Limit: lo.ToPtr(len(ids)),
 		})
 		if err != nil {
-			return nil, packet.NewError(err, inPck)
+			return nil, packet.WithError(err, inPck)
 		}
 
 		if len(specs) == 0 {
 			return nil, inPck
 		}
 		if outPayload, err := specsToExamples(specs, batch); err != nil {
-			return nil, packet.NewError(err, inPck)
+			return nil, packet.WithError(err, inPck)
 		} else {
 			return packet.New(outPayload), nil
 		}

--- a/pkg/plugin/systemx/reflect_test.go
+++ b/pkg/plugin/systemx/reflect_test.go
@@ -64,7 +64,7 @@ func TestReflectNode_Send(t *testing.T) {
 		ioPort.Link(io)
 
 		proc := process.New()
-		defer proc.Exit()
+		defer proc.Exit(nil)
 
 		ioStream := io.Open(proc)
 
@@ -108,7 +108,7 @@ func TestReflectNode_Send(t *testing.T) {
 		ioPort.Link(io)
 
 		proc := process.New()
-		defer proc.Exit()
+		defer proc.Exit(nil)
 
 		ioStream := io.Open(proc)
 
@@ -146,7 +146,7 @@ func TestReflectNode_Send(t *testing.T) {
 		ioPort.Link(io)
 
 		proc := process.New()
-		defer proc.Exit()
+		defer proc.Exit(nil)
 
 		ioStream := io.Open(proc)
 
@@ -190,7 +190,7 @@ func TestReflectNode_Send(t *testing.T) {
 		ioPort.Link(io)
 
 		proc := process.New()
-		defer proc.Exit()
+		defer proc.Exit(nil)
 
 		ioStream := io.Open(proc)
 

--- a/pkg/port/port_test.go
+++ b/pkg/port/port_test.go
@@ -94,7 +94,7 @@ func TestPort_Open(t *testing.T) {
 		proc := process.New()
 		stream := port.Open(proc)
 
-		proc.Exit()
+		proc.Exit(nil)
 
 		select {
 		case <-stream.Done():
@@ -105,7 +105,7 @@ func TestPort_Open(t *testing.T) {
 
 	t.Run("process closed", func(t *testing.T) {
 		proc := process.New()
-		proc.Exit()
+		proc.Exit(nil)
 
 		stream := port.Open(proc)
 

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -9,21 +9,21 @@ import (
 
 func TestNew(t *testing.T) {
 	proc := New()
-	defer proc.Exit()
+	defer proc.Exit(nil)
 
 	assert.NotNil(t, proc)
 }
 
 func TestProcess_ID(t *testing.T) {
 	proc := New()
-	defer proc.Exit()
+	defer proc.Exit(nil)
 
 	assert.NotEqual(t, ulid.ULID{}, proc.ID())
 }
 
 func TestProcess_Stack(t *testing.T) {
 	proc := New()
-	defer proc.Exit()
+	defer proc.Exit(nil)
 
 	assert.NotNil(t, proc.Stack())
 }
@@ -37,7 +37,7 @@ func TestProcess_Close(t *testing.T) {
 	default:
 	}
 
-	proc.Exit()
+	proc.Exit(nil)
 
 	select {
 	case <-proc.Done():

--- a/pkg/scheme/scheme.go
+++ b/pkg/scheme/scheme.go
@@ -16,7 +16,7 @@ type Scheme struct {
 	mu     sync.RWMutex
 }
 
-var _ Codec = &Scheme{}
+var _ Codec = (*Scheme)(nil)
 
 // New creates a new Scheme instance.
 func New() *Scheme {

--- a/pkg/scheme/unstructured.go
+++ b/pkg/scheme/unstructured.go
@@ -22,7 +22,7 @@ const (
 	KeyLinks     = "links"
 )
 
-var _ Spec = &Unstructured{}
+var _ Spec = (*Unstructured)(nil)
 
 // NewUnstructured returns a new Unstructured instance with an optional primitive.Map.
 func NewUnstructured(doc *primitive.Map) *Unstructured {

--- a/pkg/symbol/table.go
+++ b/pkg/symbol/table.go
@@ -8,24 +8,23 @@ import (
 	"github.com/siyul-park/uniflow/pkg/scheme"
 )
 
-type (
-	// TableOptions holds options for configuring a Table.
-	TableOptions struct {
-		LoadHooks   []LoadHook   // LoadHooks define functions to be executed on symbol loading.
-		UnloadHooks []UnloadHook // UnloadHooks define functions to be executed on symbol unloading.
-	}
+// TableOptions holds options for configuring a Table.
 
-	// Table manages the storage and operations for Symbols.
-	Table struct {
-		symbols     map[ulid.ULID]*Symbol
-		unlinks     map[ulid.ULID]map[string][]scheme.PortLocation
-		linked      map[ulid.ULID]map[string][]scheme.PortLocation
-		index       map[string]map[string]ulid.ULID
-		loadHooks   []LoadHook
-		unloadHooks []UnloadHook
-		mu          sync.RWMutex
-	}
-)
+type TableOptions struct {
+	LoadHooks   []LoadHook   // LoadHooks define functions to be executed on symbol loading.
+	UnloadHooks []UnloadHook // UnloadHooks define functions to be executed on symbol unloading.
+}
+
+// Table manages the storage and operations for Symbols.
+type Table struct {
+	symbols     map[ulid.ULID]*Symbol
+	unlinks     map[ulid.ULID]map[string][]scheme.PortLocation
+	linked      map[ulid.ULID]map[string][]scheme.PortLocation
+	index       map[string]map[string]ulid.ULID
+	loadHooks   []LoadHook
+	unloadHooks []UnloadHook
+	mu          sync.RWMutex
+}
 
 // NewTable returns a new SymbolTable with the specified options.
 func NewTable(opts ...TableOptions) *Table {


### PR DESCRIPTION
### **Changes Made**
- Added the ability to pass an error when calling `process.Exit`.
- Set an error when calling `process.Exit` in the HTTP node.

### **Related Issues**
<!-- Reference any related issues or pull requests. -->

### **Additional Information**
<!-- Add any additional information, context, or suggestions that might be relevant to this issue. -->
