### PR TITLE
feat: Add 'get' command for retrieving and displaying applied resources

### DIFF
--- a/cmd/printer/table.go
+++ b/cmd/printer/table.go
@@ -21,6 +21,15 @@ type TablePrinter struct {
 	formats []*jsonata.Expr
 }
 
+// SpecTableColumnDefinitions defines columns for displaying spec information.
+var SpecTableColumnDefinitions = []TableColumnDefinition{
+	{Name: "id", Format: "$.id"},
+	{Name: "kind", Format: "$.kind"},
+	{Name: "namespace", Format: "$.namespace"},
+	{Name: "name", Format: "$.name"},
+	{Name: "links", Format: "$.links"},
+}
+
 // style is the default style configuration for the table.
 var style = table.Style{
 	Name: "StyleDefault",

--- a/cmd/uniflow/apply/cmd.go
+++ b/cmd/uniflow/apply/cmd.go
@@ -23,15 +23,6 @@ type Config struct {
 	FS       fs.FS
 }
 
-// SpecTableColumnDefinitions defines columns for displaying spec information.
-var SpecTableColumnDefinitions = []printer.TableColumnDefinition{
-	{Name: "id", Format: "$.id"},
-	{Name: "kind", Format: "$.kind"},
-	{Name: "namespace", Format: "$.namespace"},
-	{Name: "name", Format: "$.name"},
-	{Name: "links", Format: "$.links"},
-}
-
 // NewCmd creates a new cobra.Command for the apply command.
 func NewCmd(config Config) *cobra.Command {
 	cmd := &cobra.Command{
@@ -150,7 +141,7 @@ func applySpecs(ctx context.Context, st *storage.Storage, specs []scheme.Spec) e
 }
 
 func printSpecTable(cmd *cobra.Command, specs []scheme.Spec) error {
-	tablePrinter, err := printer.NewTable(SpecTableColumnDefinitions)
+	tablePrinter, err := printer.NewTable(printer.SpecTableColumnDefinitions)
 	if err != nil {
 		return err
 	}

--- a/cmd/uniflow/apply/cmd_test.go
+++ b/cmd/uniflow/apply/cmd_test.go
@@ -65,4 +65,6 @@ func TestExecute(t *testing.T) {
 	r, err := st.FindOne(context.Background(), storage.Where[string](scheme.KeyName).EQ(spec.GetName()))
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
+
+	assert.Contains(t, output.String(), spec.Name)
 }

--- a/cmd/uniflow/cmd.go
+++ b/cmd/uniflow/cmd.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 
 	"github.com/siyul-park/uniflow/cmd/uniflow/apply"
+	"github.com/siyul-park/uniflow/cmd/uniflow/get"
 	"github.com/siyul-park/uniflow/cmd/uniflow/start"
 	"github.com/siyul-park/uniflow/pkg/database"
 	"github.com/siyul-park/uniflow/pkg/hook"
@@ -32,14 +33,18 @@ func NewCmd(config Config) *cobra.Command {
 		Long: "Create your uniflow and integrate it anywhere!",
 	}
 
-	cmd.AddCommand(start.NewCmd(start.Config{
+	cmd.AddCommand(apply.NewCmd(apply.Config{
 		Scheme:   sc,
-		Hook:     hk,
 		Database: db,
 		FS:       fsys,
 	}))
-	cmd.AddCommand(apply.NewCmd(apply.Config{
+	cmd.AddCommand(get.NewCmd(get.Config{
 		Scheme:   sc,
+		Database: db,
+	}))
+	cmd.AddCommand(start.NewCmd(start.Config{
+		Scheme:   sc,
+		Hook:     hk,
 		Database: db,
 		FS:       fsys,
 	}))

--- a/cmd/uniflow/get/cmd.go
+++ b/cmd/uniflow/get/cmd.go
@@ -11,13 +11,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Config represents the configuration for the apply command.
+// Config represents the configuration for the get command.
 type Config struct {
 	Scheme   *scheme.Scheme
 	Database database.Database
 }
 
-// NewCmd creates a new cobra.Command for the apply command.
+// NewCmd creates a new cobra.Command for the get command.
 func NewCmd(config Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get",
@@ -25,7 +25,7 @@ func NewCmd(config Config) *cobra.Command {
 		RunE:  runGetCommand(config),
 	}
 
-	cmd.PersistentFlags().StringP(FlagNamespace, flag.ToShorthand(FlagNamespace), "", "Set the resource's namespace. If not set, use the default namespace")
+	cmd.PersistentFlags().StringP(FlagNamespace, flag.ToShorthand(FlagNamespace), "", "Set the resource's namespace. If not set, use all namespace")
 
 	return cmd
 }

--- a/cmd/uniflow/get/cmd.go
+++ b/cmd/uniflow/get/cmd.go
@@ -1,0 +1,83 @@
+package get
+
+import (
+	"fmt"
+
+	"github.com/siyul-park/uniflow/cmd/flag"
+	"github.com/siyul-park/uniflow/cmd/printer"
+	"github.com/siyul-park/uniflow/pkg/database"
+	"github.com/siyul-park/uniflow/pkg/scheme"
+	"github.com/siyul-park/uniflow/pkg/storage"
+	"github.com/spf13/cobra"
+)
+
+// Config represents the configuration for the apply command.
+type Config struct {
+	Scheme   *scheme.Scheme
+	Database database.Database
+}
+
+// NewCmd creates a new cobra.Command for the apply command.
+func NewCmd(config Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get and display applied resources",
+		RunE:  runGetCommand(config),
+	}
+
+	cmd.PersistentFlags().StringP(FlagNamespace, flag.ToShorthand(FlagNamespace), "", "Set the resource's namespace. If not set, use the default namespace")
+
+	return cmd
+}
+
+func runGetCommand(config Config) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, _ []string) error {
+		ctx := cmd.Context()
+
+		ns, err := cmd.Flags().GetString(FlagNamespace)
+		if err != nil {
+			return err
+		}
+
+		st, err := storage.New(ctx, storage.Config{
+			Scheme:   config.Scheme,
+			Database: config.Database,
+		})
+		if err != nil {
+			return err
+		}
+
+		filter := createNamespaceFilter(ns)
+		specs, err := st.FindMany(ctx, filter)
+		if err != nil {
+			return err
+		}
+
+		return printSpecTable(cmd, specs)
+	}
+}
+
+func createNamespaceFilter(ns string) *storage.Filter {
+	if ns == "" {
+		return nil
+	}
+	return storage.Where[string](scheme.KeyNamespace).EQ(ns)
+}
+
+func printSpecTable(cmd *cobra.Command, specs []scheme.Spec) error {
+	tablePrinter, err := printer.NewTable(printer.SpecTableColumnDefinitions)
+	if err != nil {
+		return err
+	}
+
+	table, err := tablePrinter.Print(specs)
+	if err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprint(cmd.OutOrStdout(), table); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/uniflow/get/flag.go
+++ b/cmd/uniflow/get/flag.go
@@ -1,0 +1,5 @@
+package get
+
+const (
+	FlagNamespace = "namespace"
+)


### PR DESCRIPTION
### **Changes Made**
- Introduce a new `get` command to retrieve and display applied resources.
- Enhance the command's description for improved clarity and natural language.
- Refactor and modularize the existing code for better maintainability.

```sh
./uniflow get
 ID                          KIND    NAMESPACE  NAME    LINKS                                
 01HH8WSZC9RPTCCDQ9HDQ1TFFB  http    default    http    map[out:[map[name:router port:in]]]  
 01HH8WSZC9RPTCCDQ9HFEEQAYH  router  default    router  map[out[0]:[map[name:http port:in]]] 
```

### **Related Issues**
<!-- Add relevant issue or pull request references if applicable. -->

### **Additional Information**
<!-- Provide any additional context or suggestions for review. -->