### PR TITLE
feat: add mocker for support symbol mocking

### DIFF
--- a/pkg/testing/mocker.go
+++ b/pkg/testing/mocker.go
@@ -1,0 +1,128 @@
+package testing
+
+import (
+	"github.com/gofrs/uuid"
+	"github.com/siyul-park/uniflow/pkg/process"
+	"github.com/siyul-park/uniflow/pkg/symbol"
+	"sync"
+)
+
+// Mocker manages the creation and removal of mock connections between symbols based on port matching.
+type Mocker struct {
+	symbols    map[uuid.UUID]*symbol.Symbol
+	namespaces map[string]map[string]uuid.UUID
+	mu         sync.RWMutex
+}
+
+// NewMocker initializes and returns a new Mocker instance.
+func NewMocker() *Mocker {
+	return &Mocker{
+		symbols:    make(map[uuid.UUID]*symbol.Symbol),
+		namespaces: make(map[string]map[string]uuid.UUID),
+	}
+}
+
+var _ symbol.LoadHook = (*Mocker)(nil)
+var _ symbol.UnloadHook = (*Mocker)(nil)
+
+// Mock establishes mock connections between the provided symbol and other symbols based on matching ports.
+func (m *Mocker) Mock(proc *process.Process, mock *symbol.Symbol) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	sb, ok := m.symbols[mock.ID()]
+	if !ok || sb == mock {
+		return nil
+	}
+
+	for name, ports := range mock.Ports() {
+		out := mock.Out(name)
+		for _, port := range ports {
+			id := port.ID
+			if id == uuid.Nil {
+				id = m.lookup(sb.Namespace(), port.Name)
+			}
+
+			if ref, ok := m.symbols[id]; ok {
+				if ref.Namespace() == sb.Namespace() {
+					in := ref.In(port.Port)
+					if out != nil && in != nil {
+						out.Link(in)
+					}
+				}
+			}
+		}
+	}
+
+	for _, ref := range m.symbols {
+		if ref.Namespace() != sb.Namespace() {
+			continue
+		}
+		for name, ports := range ref.Ports() {
+			out := ref.Out(name)
+			for _, port := range ports {
+				id := port.ID
+				if id == uuid.Nil {
+					id = m.lookup(ref.Namespace(), port.Name)
+				}
+
+				if id == mock.ID() {
+					writer := out.Open(proc)
+					if in := mock.In(port.Port); in != nil {
+						reader := in.Open(proc)
+						writer.Link(reader)
+					}
+					if in := sb.In(port.Port); in != nil {
+						reader := in.Open(proc)
+						writer.Unlink(reader)
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// Load adds the symbol to the symbol map and its namespace.
+func (m *Mocker) Load(sb *symbol.Symbol) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.symbols[sb.ID()] = sb
+
+	if sb.Name() != "" {
+		ns, ok := m.namespaces[sb.Namespace()]
+		if !ok {
+			ns = make(map[string]uuid.UUID)
+			m.namespaces[sb.Namespace()] = ns
+		}
+		ns[sb.Name()] = sb.ID()
+	}
+	return nil
+}
+
+// Unload removes the symbol from the symbol map and cleans up its namespace.
+func (m *Mocker) Unload(sb *symbol.Symbol) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Clean up the namespace if the symbol has a name.
+	if sb.Name() != "" {
+		if ns, ok := m.namespaces[sb.Namespace()]; ok {
+			delete(ns, sb.Name())
+			if len(ns) == 0 {
+				delete(m.namespaces, sb.Namespace())
+			}
+		}
+	}
+
+	delete(m.symbols, sb.ID())
+	return nil
+}
+
+func (m *Mocker) lookup(namespace, name string) uuid.UUID {
+	if ns, ok := m.namespaces[namespace]; ok {
+		return ns[name]
+	}
+	return uuid.Nil
+}

--- a/pkg/testing/mocker_test.go
+++ b/pkg/testing/mocker_test.go
@@ -1,0 +1,99 @@
+package testing
+
+import (
+	"github.com/go-faker/faker/v4"
+	"github.com/gofrs/uuid"
+	"github.com/siyul-park/uniflow/pkg/node"
+	"github.com/siyul-park/uniflow/pkg/process"
+	"github.com/siyul-park/uniflow/pkg/resource"
+	"github.com/siyul-park/uniflow/pkg/spec"
+	"github.com/siyul-park/uniflow/pkg/symbol"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMocker_Mock(t *testing.T) {
+	m := NewMocker()
+
+	sb1 := &symbol.Symbol{
+		Spec: &spec.Meta{
+			ID:        uuid.Must(uuid.NewV7()),
+			Kind:      faker.UUIDHyphenated(),
+			Namespace: resource.DefaultNamespace,
+			Name:      faker.UUIDHyphenated(),
+		},
+		Node: node.NewOneToOneNode(nil),
+	}
+	defer sb1.Close()
+
+	sb2 := &symbol.Symbol{
+		Spec: &spec.Meta{
+			ID:        uuid.Must(uuid.NewV7()),
+			Kind:      faker.UUIDHyphenated(),
+			Namespace: resource.DefaultNamespace,
+			Name:      faker.UUIDHyphenated(),
+		},
+		Node: node.NewOneToOneNode(nil),
+	}
+	defer sb2.Close()
+
+	sb3 := &symbol.Symbol{
+		Spec: &spec.Meta{
+			ID:        uuid.Must(uuid.NewV7()),
+			Kind:      faker.UUIDHyphenated(),
+			Namespace: resource.DefaultNamespace,
+			Name:      faker.UUIDHyphenated(),
+		},
+		Node: node.NewOneToOneNode(nil),
+	}
+	defer sb3.Close()
+
+	sb1.Spec.SetPorts(map[string][]spec.Port{
+		node.PortOut: {
+			{
+				ID:   sb2.ID(),
+				Port: node.PortIn,
+			},
+		},
+	})
+	sb2.Spec.SetPorts(map[string][]spec.Port{
+		node.PortOut: {
+			{
+				ID:   sb3.ID(),
+				Port: node.PortIn,
+			},
+		},
+	})
+
+	sb1.Out(node.PortOut).Link(sb2.In(node.PortIn))
+	sb2.Out(node.PortOut).Link(sb3.In(node.PortIn))
+
+	m.Load(sb1)
+	defer m.Unload(sb1)
+
+	m.Load(sb2)
+	defer m.Unload(sb2)
+
+	m.Load(sb3)
+	defer m.Unload(sb3)
+
+	proc := process.New()
+	defer proc.Exit(nil)
+
+	sb4 := &symbol.Symbol{
+		Spec: sb2.Spec,
+		Node: node.NewOneToOneNode(nil),
+	}
+	defer sb4.Close()
+
+	err := m.Mock(proc, sb4)
+	assert.NoError(t, err)
+
+	out := sb1.Out(node.PortOut)
+	writer := out.Open(proc)
+	assert.Len(t, writer.Links(), 1)
+
+	out = sb4.Out(node.PortOut)
+	writer = out.Open(proc)
+	assert.Len(t, writer.Links(), 1)
+}


### PR DESCRIPTION
### **Changes Made**
<!-- Outline the key changes you made in this pull request. -->

The `Mocker` struct is designed to facilitate testing by dynamically replacing symbols in a running process with mock objects. It manages all symbols loaded at runtime, ensuring that connections between existing symbols are severed and substituted with mock implementations.

### **Related Issues**
<!-- Reference any related issues or pull requests. -->

### **Additional Information**
<!-- Add any additional information, context, or suggestions that might be relevant to this issue. -->


